### PR TITLE
Corrige o % de juros na fórmula

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -21,7 +21,7 @@ namespace JurosSimples
             i = Convert.ToDecimal(ent2);
             t = Convert.ToInt16(ent3);
 
-            j = c * i * t;
+            j = c * (i/100) * t;
             m = (c + j);
             
             Console.WriteLine();


### PR DESCRIPTION
O usuário digitará 2, o que significa 2 por cento.
A fórmula deve cobrir isto.